### PR TITLE
add hide_text knob to read_pdf / read_pixmap / read

### DIFF
--- a/pdffile/__init__.py
+++ b/pdffile/__init__.py
@@ -20,6 +20,8 @@ if TYPE_CHECKING:
     from collections.abc import Mapping
     from datetime import datetime
 
+    from pymupdf import Page
+
 FALSY: set[None | bool | str] = {None, "", "false", "0", False}
 LOG: Logger = getLogger(__name__)
 
@@ -171,25 +173,97 @@ class PDFFile:
         image_dict = self._doc.extract_image(xref)
         return image_dict["image"], image_dict["ext"]
 
-    def read_pixmap(self, index: int) -> tuple[bytes, str]:
-        """Convert page to pixmap."""
-        pix = self._doc.get_page_pixmap(index)
+    @staticmethod
+    def _prepend_invisible_text_op(doc: Document, page: Page) -> None:
+        """
+        Prepend ``3 Tr`` to ``page``'s ``/Contents``.
+
+        ``3 Tr`` sets text rendering mode 3 (invisible) at the start of
+        the page's graphics state. Any text-showing operator that runs
+        afterwards still consumes the operands and advances the text
+        matrix — so PDF text extraction still works — but no glyphs
+        are drawn. Useful for badly-OCR'd PDFs that draw OCR text with
+        the default (visible) rendering mode on top of an already-
+        rasterized page, doubling the text under any renderer that
+        respects the content stream.
+        """
+        new_xref = doc.get_new_xref()
+        doc.update_object(new_xref, "<<>>")
+        doc.update_stream(new_xref, b"3 Tr\n")
+        original_xrefs = page.get_contents()
+        new_array = (
+            "[" + " ".join(f"{x} 0 R" for x in [new_xref, *original_xrefs]) + "]"
+        )
+        doc.xref_set_key(page.xref, "Contents", new_array)
+
+    @classmethod
+    def _hide_text_in_pdf_bytes(cls, pdf_bytes: bytes) -> bytes:
+        """
+        Return ``pdf_bytes`` with ``3 Tr`` prepended to every page.
+
+        Operates on a fresh ``Document`` opened from ``pdf_bytes`` so
+        ``self._doc`` is never mutated — important because ``close()``
+        flushes a dirty doc back to disk.
+        """
+        with Document(stream=pdf_bytes, filetype="pdf") as out:
+            for page in out:
+                cls._prepend_invisible_text_op(out, page)
+            return out.tobytes()
+
+    def read_pixmap(self, index: int, *, hide_text: bool = False) -> tuple[bytes, str]:
+        """
+        Convert page to pixmap.
+
+        With ``hide_text=True``, suppress visible text rendering so a
+        rasterized OCR overlay doesn't double up against the page's
+        baked-in scan.
+        """
         output = "ppm"
+        if hide_text:
+            # Build a one-page copy via convert_to_pdf, hide text in
+            # the copy, render. Avoids mutating ``self._doc`` (which
+            # would dirty it and trigger a save on close).
+            pdf_bytes = self._hide_text_in_pdf_bytes(
+                self._doc.convert_to_pdf(index, index)
+            )
+            with Document(stream=pdf_bytes, filetype="pdf") as tmp:
+                pix = tmp[0].get_pixmap()
+        else:
+            pix = self._doc.get_page_pixmap(index)
         return pix.tobytes(output=output), output
 
-    def read_pdf(self, index: int) -> tuple[bytes, str]:
-        """Read a pdf page as complete one page pdf."""
-        return self._doc.convert_to_pdf(index, index), "pdf"
+    def read_pdf(self, index: int, *, hide_text: bool = False) -> tuple[bytes, str]:
+        """
+        Read a pdf page as complete one page pdf.
+
+        With ``hide_text=True``, the returned PDF renders text in mode
+        3 (invisible) — text content is still extractable / selectable
+        but won't be drawn on top of the page's raster.
+        """
+        pdf_bytes = self._doc.convert_to_pdf(index, index)
+        if hide_text:
+            pdf_bytes = self._hide_text_in_pdf_bytes(pdf_bytes)
+        return pdf_bytes, "pdf"
 
     def read_embedded_file(self, filename: str) -> tuple[bytes, str]:
         """Read embedded file."""
         return self._doc.embfile_get(filename), Path(filename).suffix[:1]
 
-    def read(self, filename: str, fmt: str = "", props: dict | None = None) -> bytes:
+    def read(
+        self,
+        filename: str,
+        fmt: str = "",
+        props: dict | None = None,
+        *,
+        hide_text: bool = False,
+    ) -> bytes:
         """
         Return a single page pdf doc, image or pixmap or embedded file.
 
         If a props dict is passed in, the read file extension is written it on the 'ext' key.
+        ``hide_text`` is forwarded to ``read_pdf`` / ``read_pixmap``;
+        the embedded-image and embedded-file paths ignore it (those
+        bypass the content stream entirely).
         """
         try:
             if not fmt:
@@ -202,11 +276,11 @@ class PDFFile:
                     LOG.warning(
                         f"Unable to extract first image from page, converting to pixmap: {exc}"
                     )
-                    page_bytes, ext = self.read_pixmap(index)
+                    page_bytes, ext = self.read_pixmap(index, hide_text=hide_text)
             elif fmt == PageFormat.PIXMAP.value:
-                page_bytes, ext = self.read_pixmap(index)
+                page_bytes, ext = self.read_pixmap(index, hide_text=hide_text)
             else:
-                page_bytes, ext = self.read_pdf(index)
+                page_bytes, ext = self.read_pdf(index, hide_text=hide_text)
         except ValueError:
             page_bytes, ext = self.read_embedded_file(filename)
         if props is not None:

--- a/tests/test_hide_text.py
+++ b/tests/test_hide_text.py
@@ -1,0 +1,88 @@
+"""Tests for the ``hide_text`` knob on read_pdf / read_pixmap / read."""
+
+from pathlib import Path
+
+import pymupdf
+
+from pdffile import PageFormat, PDFFile
+
+_FIXTURE = Path(__file__).parent / "test_pdf.pdf"
+
+
+def test_pixmap_hide_text_changes_rendering():
+    """``hide_text=True`` produces a different pixmap than the default."""
+    pdf = PDFFile(_FIXTURE)
+    try:
+        baseline, _ = pdf.read_pixmap(0)
+        hidden, _ = pdf.read_pixmap(0, hide_text=True)
+        assert baseline != hidden
+    finally:
+        pdf.close()
+
+
+def test_pixmap_hide_text_restores_source_doc():
+    """A hide_text call must not leave the source document mutated."""
+    pdf = PDFFile(_FIXTURE)
+    try:
+        baseline, _ = pdf.read_pixmap(0)
+        pdf.read_pixmap(0, hide_text=True)
+        restored, _ = pdf.read_pixmap(0)
+        assert restored == baseline
+    finally:
+        pdf.close()
+
+
+def test_pdf_hide_text_renders_differently():
+    """The PDF returned with hide_text renders without visible text."""
+    pdf = PDFFile(_FIXTURE)
+    try:
+        baseline, _ = pdf.read_pdf(0)
+        hidden, _ = pdf.read_pdf(0, hide_text=True)
+        # Bytes must differ — the prepended ``3 Tr`` op is in the hidden form.
+        assert baseline != hidden
+        with (
+            pymupdf.open(stream=baseline, filetype="pdf") as base_doc,
+            pymupdf.open(stream=hidden, filetype="pdf") as hidden_doc,
+        ):
+            # Text must remain extractable — we changed rendering mode,
+            # not the text content itself.
+            assert hidden_doc[0].get_text() == base_doc[0].get_text()
+            base_pix = base_doc[0].get_pixmap().tobytes("ppm")
+            hidden_pix = hidden_doc[0].get_pixmap().tobytes("ppm")
+            assert base_pix != hidden_pix
+    finally:
+        pdf.close()
+
+
+def test_read_dispatches_hide_text_to_pixmap_and_pdf():
+    """``PDFFile.read`` forwards ``hide_text`` to the right backend."""
+    pdf = PDFFile(_FIXTURE)
+    try:
+        # Pixmap path.
+        baseline = pdf.read("0", fmt=PageFormat.PIXMAP.value)
+        hidden = pdf.read("0", fmt=PageFormat.PIXMAP.value, hide_text=True)
+        assert baseline != hidden
+        # Default (PDF) path.
+        baseline_pdf = pdf.read("0")
+        hidden_pdf = pdf.read("0", hide_text=True)
+        assert baseline_pdf != hidden_pdf
+    finally:
+        pdf.close()
+
+
+def test_read_image_unaffected_by_hide_text():
+    """The embedded-image path bypasses the content stream entirely."""
+    pdf = PDFFile(_FIXTURE)
+    try:
+        # Use a fixture page that has no embedded image — the read()
+        # fallback should land on read_pixmap, where hide_text *does*
+        # change output. Sanity-check that the IMAGE path itself returns
+        # identical bytes if it succeeds (i.e. for a page that has an
+        # extractable embedded image). The test fixture has no images
+        # so we only exercise the fallback path here.
+        with_text = pdf.read("0", fmt=PageFormat.IMAGE.value)
+        without_text = pdf.read("0", fmt=PageFormat.IMAGE.value, hide_text=True)
+        # Fallback to pixmap means hide_text *does* take effect.
+        assert with_text != without_text
+    finally:
+        pdf.close()


### PR DESCRIPTION
## Summary

Some scanned PDFs draw their OCR text with rendering mode 0 (visible) on top of the rasterized page, doubling the text under any renderer that respects the content stream. Properly OCR'd PDFs emit `3 Tr` to make the text invisible-but-selectable; this PR gives callers a way to do the same on the fly.

When `hide_text=True`:

- `read_pdf` returns a one-page PDF with `3 Tr` prepended to every page so the rendered output has no visible glyphs but `get_text` / selection / search still work.
- `read_pixmap` rasterizes a hide-text copy.
- `read_image` and the embedded-file path are unaffected — they bypass the content stream entirely.

Implementation operates on a fresh `Document` opened from `convert_to_pdf` bytes via the new private `_hide_text_in_pdf_bytes` helper, so `self._doc` is never mutated. An earlier draft mutated-and-restored, which left `is_dirty=True` and silently overwrote the source file via `close()` → `save()` — keeping the source doc immutable on the read path is the safer invariant.

## Test plan

- [x] New `tests/test_hide_text.py` covers all five paths: pixmap-changes-rendering, pixmap-restores-source-doc, pdf-renders-differently (also asserts text remains extractable), `read()` dispatch to both pixmap/pdf, and the image-fallback path.
- [x] Full suite passes (6 tests).
- [x] Lint (ruff, ty) clean.
- [x] Verified on a real badly-OCR'd PDF — file mtime/size unchanged after `read_pixmap(..., hide_text=True)` + `close()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)