### PR TITLE
read_pdf: use insert_pdf, not convert_to_pdf

### DIFF
--- a/pdffile/__init__.py
+++ b/pdffile/__init__.py
@@ -178,8 +178,23 @@ class PDFFile:
         return pix.tobytes(output=output), output
 
     def read_pdf(self, index: int) -> tuple[bytes, str]:
-        """Read a pdf page as complete one page pdf."""
-        return self._doc.convert_to_pdf(index, index), "pdf"
+        """
+        Read a pdf page as a complete one-page pdf.
+
+        Uses ``insert_pdf`` rather than ``Document.convert_to_pdf``:
+        the latter rebuilds the page's content stream and during that
+        rebuild it drops text rendering mode operators (notably ``3 Tr``,
+        invisible text) and renames specialised OCR fonts like
+        ``HiddenHorzOCR`` to ordinary text fonts. The net effect on
+        Acrobat-OCR'd PDFs is that the invisible OCR overlay turns
+        visible — text "doubles up" against the page's raster under any
+        renderer that follows the spec (PDF.js, MuPDF itself).
+        ``insert_pdf`` copies the page faithfully — same operators,
+        same fonts, no warnings, pixel-identical render to the source.
+        """
+        out = Document()
+        out.insert_pdf(self._doc, from_page=index, to_page=index)
+        return out.tobytes(), "pdf"
 
     def read_embedded_file(self, filename: str) -> tuple[bytes, str]:
         """Read embedded file."""

--- a/tests/test_invisible_text.pdf
+++ b/tests/test_invisible_text.pdf
@@ -1,0 +1,33 @@
+%PDF-1.4
+%‚„œ”
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Count 1 /Kids [ 3 0 R ] >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 200 200] /Resources << /Font << /F0 4 0 R >> >> /Contents 5 0 R >>
+endobj
+4 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+5 0 obj
+<< /Length 75 >>
+stream
+q 0 0 0 rg 75 75 50 50 re f BT /F0 20 Tf 3 Tr 20 100 Td (INVISIBLE) Tj ET Q
+endstream
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000015 00000 n 
+0000000064 00000 n 
+0000000123 00000 n 
+0000000249 00000 n 
+0000000319 00000 n 
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+444
+%%EOF

--- a/tests/test_read_pdf_preserves_3tr.py
+++ b/tests/test_read_pdf_preserves_3tr.py
@@ -1,0 +1,83 @@
+"""
+``read_pdf`` must preserve the ``3 Tr`` invisible-text operator.
+
+Acrobat-OCR'd PDFs put the OCR overlay in text rendering mode 3
+(invisible) so it's selectable but not drawn. ``Document.convert_to_pdf``
+rebuilds the page and drops those operators — the OCR text becomes
+visible against the page raster, "doubling up." ``insert_pdf`` copies
+the page faithfully and keeps the operator. This test guards against a
+regression to the ``convert_to_pdf`` path.
+
+The fixture is a 627-byte hand-coded PDF with ``3 Tr`` followed by a
+text-show operator on a 200x200 page; that's the smallest possible
+shape that makes the bug visible.
+"""
+
+from pathlib import Path
+
+import pymupdf
+
+from pdffile import PDFFile
+
+_FIXTURE = Path(__file__).parent / "test_invisible_text.pdf"
+
+
+def _tr_modes(content: bytes) -> list[bytes]:
+    """Return text rendering mode operands found in a content stream."""
+    import re
+
+    return re.findall(rb"(\d+)\s+Tr\b", content)
+
+
+def test_fixture_has_invisible_text():
+    """Sanity check on the fixture itself."""
+    doc = pymupdf.open(_FIXTURE)
+    try:
+        assert doc.page_count == 1
+        modes = _tr_modes(doc[0].read_contents())
+        assert modes == [b"3"], f"expected [b'3'], got {modes}"
+    finally:
+        doc.close()
+
+
+def test_read_pdf_preserves_invisible_text_mode():
+    """``read_pdf`` output keeps the ``3 Tr`` operator."""
+    pdf = PDFFile(_FIXTURE)
+    try:
+        out_bytes, ext = pdf.read_pdf(0)
+    finally:
+        pdf.close()
+    assert ext == "pdf"
+    out = pymupdf.open(stream=out_bytes, filetype="pdf")
+    try:
+        modes = _tr_modes(out[0].read_contents())
+        assert modes == [b"3"], (
+            f"read_pdf stripped the invisible-text mode (got {modes}); "
+            "this regresses to the convert_to_pdf path that corrupts "
+            "Acrobat-OCR'd PDFs"
+        )
+    finally:
+        out.close()
+
+
+def test_read_pdf_renders_identically_to_source():
+    """Single-page extract via read_pdf must render pixel-identically."""
+    src = pymupdf.open(_FIXTURE)
+    try:
+        src_pix = src[0].get_pixmap().tobytes("ppm")
+    finally:
+        src.close()
+
+    pdf = PDFFile(_FIXTURE)
+    try:
+        out_bytes, _ = pdf.read_pdf(0)
+    finally:
+        pdf.close()
+
+    out = pymupdf.open(stream=out_bytes, filetype="pdf")
+    try:
+        out_pix = out[0].get_pixmap().tobytes("ppm")
+    finally:
+        out.close()
+
+    assert out_pix == src_pix


### PR DESCRIPTION
## Summary

`Document.convert_to_pdf` rebuilds the page's content stream from scratch. During that rebuild it:

1. **Drops text rendering mode operators** — notably `3 Tr` (invisible).
2. **Renames specialised OCR fonts** like `HiddenHorzOCR` to ordinary text fonts (`Times-Bold`, `Helvetica`, etc.) and emits warnings (`cannot create ToUnicode mapping for HiddenHorzOCR`, many `FT_Get_Advance(HiddenHorzOCR, …): invalid glyph index`).

On Acrobat-OCR'd PDFs the combination turns the invisible OCR overlay **visible** — text "doubles up" against the page's raster under any spec-compliant renderer (PDF.js in vue-pdf-embed, MuPDF rendering itself, etc.). Browsers/Preview that use vendor-specific OCR-overlap heuristics happen to mask it; renderers that follow the spec don't.

`insert_pdf` copies the page faithfully — same operators, same fonts, no warnings, pixel-identical render to the source. Drop-in fix; no API change.

## Verified on a real file

Tested against an Acrobat-OCR'd 92-page PDF (`Adobe Acrobat 9.55 Paper Capture Plug-in`):

| extract method | `3 Tr` preserved | rendered diff vs source |
|---|---|---|
| `convert_to_pdf(2, 2)` | **stripped** | 15.34% pixels differ |
| `insert_pdf(..., from_page=2, to_page=2)` (this PR) | preserved | **0.00% — pixel-identical** |

## Test plan

- [x] New `tests/test_read_pdf_preserves_3tr.py` covers: fixture sanity, `read_pdf` keeps `3 Tr`, `read_pdf` renders identically to source.
- [x] Fixture is a 627-byte hand-coded PDF (`tests/test_invisible_text.pdf`) — smallest shape that exhibits the bug. Replacing `insert_pdf` with `convert_to_pdf` makes the new tests fail (verified locally).
- [x] Existing tests (`test_is_pdffile.py`) still pass — total 4/4.
- [x] Lint (ruff, ty) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)